### PR TITLE
Create Floyd-Warshall-Algorithm.java

### DIFF
--- a/Algorithms/Floyd-Warshall-Algorithm.java
+++ b/Algorithms/Floyd-Warshall-Algorithm.java
@@ -1,0 +1,58 @@
+import java.util.Arrays;
+
+public class FloydWarshallAlgorithm {
+    final static int INF = 99999; // Represents infinity
+
+    // Function to implement Floyd-Warshall Algorithm
+    void floydWarshall(int graph[][], int V) {
+        int dist[][] = new int[V][V];
+
+        // Initialize the solution matrix with the input graph matrix
+        for (int i = 0; i < V; i++)
+            for (int j = 0; j < V; j++)
+                dist[i][j] = graph[i][j];
+
+        // Applying the Floyd-Warshall algorithm
+        for (int k = 0; k < V; k++) {
+            for (int i = 0; i < V; i++) {
+                for (int j = 0; j < V; j++) {
+                    // If vertex k is on the shortest path from i to j,
+                    // update the value of dist[i][j]
+                    if (dist[i][k] + dist[k][j] < dist[i][j])
+                        dist[i][j] = dist[i][k] + dist[k][j];
+                }
+            }
+        }
+
+        // Print the shortest distance matrix
+        printSolution(dist, V);
+    }
+
+    // Function to print the shortest distance matrix
+    void printSolution(int dist[][], int V) {
+        System.out.println("Shortest distances between every pair of vertices:");
+        for (int i = 0; i < V; i++) {
+            for (int j = 0; j < V; j++) {
+                if (dist[i][j] == INF)
+                    System.out.print("INF ");
+                else
+                    System.out.print(dist[i][j] + " ");
+            }
+            System.out.println();
+        }
+    }
+
+    // Driver method to test the algorithm
+    public static void main(String[] args) {
+        FloydWarshallAlgorithm fwa = new FloydWarshallAlgorithm();
+        int graph[][] = {
+            {0, 5, INF, 10},
+            {INF, 0, 3, INF},
+            {INF, INF, 0, 1},
+            {INF, INF, INF, 0}
+        };
+        int V = 4; // Number of vertices in the graph
+
+        fwa.floydWarshall(graph, V);
+    }
+}


### PR DESCRIPTION
The Floyd-Warshall Algorithm is an all-pairs shortest path algorithm used to find the shortest distances between every pair of nodes in a weighted graph. It efficiently handles both positive and negative edge weights, but no negative cycles. The algorithm works by iteratively updating the shortest path between each pair of nodes, considering each node as an intermediate step. The time complexity is O(V³), where V is the number of vertices. It’s a dynamic programming approach that results in a distance matrix showing the shortest path between all nodes.